### PR TITLE
Fix/pnf

### DIFF
--- a/mtl/mtl.py
+++ b/mtl/mtl.py
@@ -68,11 +68,12 @@ class MTLFormula(object):
 
         self.__string = None
         self.__hash = None
-    
+
     def negate(self):
         '''Computes the negation of the MTL formula by propagating the negation
         towards predicates.
         '''
+        self.__string = None
         if self.op == Operation.BOOL:
             self.value = not self.value
         elif self.op == Operation.PRED:
@@ -90,11 +91,12 @@ class MTLFormula(object):
         self.op = Operation.negop[self.op]
         return self
 
-    def pnf(self):
+    def pnf(self, insert_negation_variables=False):
         '''Computes the Positive Normal Form of the MTL formula.
 
         Note: The tree structure is modified in-place.
         '''
+        self.__string = None
         if self.op in (Operation.AND, Operation.OR):
             self.children = [child.pnf() for child in self.children]
         elif self.op == Operation.IMPLIES:
@@ -104,6 +106,9 @@ class MTLFormula(object):
         elif self.op == Operation.NOT:
             if self.child.op != Operation.PRED:
                 return self.child.negate().pnf()
+            elif insert_negation_variables:
+                self.child.variable = f'{self.child.variable}_neg'
+                return self.child
         elif self.op == Operation.UNTIL:
             raise NotImplementedError
         elif self.op in (Operation.ALWAYS, Operation.EVENT):
@@ -245,4 +250,3 @@ if __name__ == '__main__':
 
     ast = MTLAbstractSyntaxTreeExtractor().visit(t)
     print('AST:', str(ast))
-    

--- a/stl/stl.py
+++ b/stl/stl.py
@@ -173,44 +173,58 @@ class STLFormula(object):
         self.op = Operation.negop[self.op]
         return self
 
-    def pnf(self):
+    def pnf(self, insert_inverse_variables=False):
         '''Computes the Positive Normal Form of the STL formula, potentially
         adding new variables.
 
         Note: The tree structure is modified in-place.
         '''
         self.__string = None
+        flag = insert_inverse_variables
         if self.op == Operation.PRED:
             if self.relation in (RelOperation.LE, RelOperation.LT):
-                self.relation = RelOperation.invop[self.relation]
-                self.variable = f'{self.variable}_neg'
-                self.threshold = -self.threshold
-            elif self.relation == RelOperation.EQ:
-                children = [STLFormula(Operation.PRED, relation=RelOperation.GE,
+                if insert_inverse_variables:
+                    self.relation = RelOperation.invop[self.relation]
+                    self.variable = f'{self.variable}_neg'
+                    self.threshold = -self.threshold
+            elif self.relation in (RelOperation.EQ, RelOperation.NQ):
+                if self.relation == RelOperation.EQ:
+                    op = Operation.AND
+                    rel1 = RelOperation.GE
+                else: # self.relation == RelOperation.NQ
+                    op = Operation.OR
+                    rel1 = RelOperation.GT
+                if insert_inverse_variables:
+                    if self.relation == RelOperation.EQ:
+                        rel2 = RelOperation.GE
+                    else: # self.relation == RelOperation.NQ
+                        rel2 = RelOperation.GT
+                    var_neg = f'{self.variable}_neg'
+                    thr = -self.threshold
+                else:
+                    if self.relation == RelOperation.EQ:
+                        rel2 = RelOperation.LE
+                    else: # self.relation == RelOperation.NQ
+                        rel2 = RelOperation.LT
+                    var_neg = self.variable
+                    thr = self.threshold
+                children = [STLFormula(Operation.PRED, relation=rel1,
                               variable=self.variable, threshold=self.threshold),
-                            STLFormula(Operation.PRED, relation=RelOperation.GE,
-                              variable=f'{self.variable}_neg',
-                              threshold=-self.threshold)]
-                return STLFormula(Operation.AND, children=children)
-            elif self.relation == RelOperation.NQ:
-                children = [STLFormula(Operation.PRED, relation=RelOperation.GT,
-                              variable=self.variable, threshold=self.threshold),
-                            STLFormula(Operation.PRED, relation=RelOperation.GT,
-                              variable=f'{self.variable}_neg',
-                              threshold=-self.threshold)]
-                return STLFormula(Operation.OR, children=children)
+                            STLFormula(Operation.PRED, relation=rel2,
+                              variable=var_neg, threshold=thr)]
+                return STLFormula(op, children=children)
         elif self.op in (Operation.AND, Operation.OR):
-            self.children = [child.pnf() for child in self.children]
+            self.children = [child.pnf(flag) for child in self.children]
         elif self.op == Operation.IMPLIES:
-            self.left = self.left.negate().pnf()
-            self.right = self.right.pnf()
+            self.left = self.left.negate().pnf(flag)
+            self.right = self.right.pnf(flag)
             self.op = Operation.OR
         elif self.op == Operation.NOT:
-            return self.child.negate().pnf()
+            return self.child.negate().pnf(flag)
         elif self.op == Operation.UNTIL:
             raise NotImplementedError
         elif self.op in (Operation.ALWAYS, Operation.EVENT):
-            self.child = self.child.pnf()
+            self.child = self.child.pnf(flag)
         return self
 
     def bound(self):

--- a/stl/stl2milp.py
+++ b/stl/stl2milp.py
@@ -86,7 +86,6 @@ class stl2milp(object):
             name='{}_{}'.format(state, t)
             v = self.model.addVar(vtype=vtype, lb=low, ub=high, name=name)
             self.variables[state][t] = v
-            print 'Added state:', state, 'time:', t
             self.model.update()
         return self.variables[state][t]
 
@@ -100,7 +99,6 @@ class stl2milp(object):
         elif pred.relation in (RelOperation.LE, RelOperation.LT):
             self.model.addConstr(v + self.M * z >= pred.threshold - self.rho)
             self.model.addConstr(v - self.M * (1 - z) <= pred.threshold - self.rho)
-#            raise NotImplementedError
         else:
             raise NotImplementedError
 


### PR DESCRIPTION
Fixed problem with string representation of a formula changed in-place by the `pnf()` and `negate()` methods for STL and MTL.
Also, extended the functionality with an option to decide whether additional variables and predicates are to be inserted in the `pnf()` method.